### PR TITLE
chore: format lists to look nice on all screen sizes

### DIFF
--- a/app/anime/[id]/components/character-list.tsx
+++ b/app/anime/[id]/components/character-list.tsx
@@ -6,71 +6,84 @@ import { Button } from "@/components/ui/button";
 
 import { CharacterFragment } from "@/graphql/types";
 
-import { ArrowDown, ArrowUp } from 'lucide-react';
+import { ArrowDown, ArrowUp } from "lucide-react";
 import CustomImage from "@/components/ui/custom-image";
 
 interface CharacterListProps {
-    quantity?: number;
-    list: CharacterFragment;
+  quantity?: number;
+  list: CharacterFragment;
 }
 
 export function CharacterList({ list, quantity }: CharacterListProps) {
+  quantity = quantity || list.edges?.length || 5;
 
-    quantity = quantity || list.edges?.length || 5;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const displayedList = isExpanded
+    ? list.edges
+    : list.edges?.slice(0, quantity);
 
-    const [isExpanded, setIsExpanded] = useState(false);
-    const displayedList = isExpanded ? list.edges : list.edges?.slice(0, quantity);
+  const toggleExpanded = () => {
+    setIsExpanded(!isExpanded);
+  };
 
-    const toggleExpanded = () => {
-        setIsExpanded(!isExpanded);
-    };
+  return (
+    <>
+      <div className="mt-4 flex flex-wrap gap-4 select-none relative">
+        {list.edges && list.edges.length > quantity && !isExpanded && (
+          <div className="absolute inset-0 bottom-0 bg-gradient-to-t from-background via-transparent to-transparent pointer-events-none z-[81]"></div>
+        )}
+        {displayedList &&
+          displayedList.map((character, index) => (
+            <div
+              key={index}
+              className="relative overflow-hidden cursor-pointer group"
+            >
+              <CustomImage
+                index={index}
+                src={character?.node?.image?.large || "/default.png"}
+                alt={character?.node?.name?.userPreferred || "No Title"}
+                width={640}
+                height={600}
+                className="w-full h-full rounded-lg transition-opacity object-cover opacity-80 group-hover:opacity-100"
+              />
 
-    return (
-        <>
-            <div className="mt-4 grid grid-cols-2 md:grid-cols-2 lg:grid-cols-5 gap-4 select-none relative">
-                {list.edges && list.edges.length > quantity && !isExpanded && (
-                    <div className="absolute inset-0 bottom-0 bg-gradient-to-t from-background via-transparent to-transparent pointer-events-none z-[81]"></div>
-                )}
-                {displayedList && displayedList.map((character, index) => (<div
-                    key={index}
-                    className="relative overflow-hidden cursor-pointer group"
-                >
-                    <CustomImage
-                        index={index}
-                        src={character?.node?.image?.large || "/default.png"}
-                        alt={character?.node?.name?.userPreferred || "No Title"}
-                        width={640}
-                        height={600}
-                        className="w-full h-full rounded-lg transition-opacity object-cover opacity-80 group-hover:opacity-100"
-                    />
-
-                    <div className="absolute bottom-0 w-full p-4 z-50 font-aeonik">
-                        <h2 className="font-medium text-md lg:w-[80%] leading-5 text-primary/80">
-                            {(character?.node?.name?.userPreferred || "No Title").length > 40
-                                ? (character?.node?.name?.userPreferred || "No Title").slice(0, 37) + "..."
-                                : character?.node?.name?.userPreferred || "No Title"}
-                        </h2>
-                        <p className="text-[12px] mt-1 text-primary/70">
-                            {character?.role ? character?.role.charAt(0) + character?.role.slice(1).toLowerCase() : "Unknown"}
-                        </p>
-                    </div>
-                    {/* Render the anime gradient overlay */}
-                    <div className="absolute inset-0 bg-gradient-to-t from-10% from-black via-[transparent] to-transparent opacity-70 rounded-lg pointer-events-none"></div>
-                </div>
-                ))}
+              <div className="absolute bottom-0 w-full p-4 z-50 font-aeonik">
+                <h2 className="font-medium text-md lg:w-[80%] leading-5 text-primary/80">
+                  {(character?.node?.name?.userPreferred || "No Title").length >
+                  40
+                    ? (
+                        character?.node?.name?.userPreferred || "No Title"
+                      ).slice(0, 37) + "..."
+                    : character?.node?.name?.userPreferred || "No Title"}
+                </h2>
+                <p className="text-[12px] mt-1 text-primary/70">
+                  {character?.role
+                    ? character?.role.charAt(0) +
+                      character?.role.slice(1).toLowerCase()
+                    : "Unknown"}
+                </p>
+              </div>
+              {/* Render the anime gradient overlay */}
+              <div className="absolute inset-0 bg-gradient-to-t from-10% from-black via-[transparent] to-transparent opacity-70 rounded-lg pointer-events-none"></div>
             </div>
-            {list.edges && list.edges.length > quantity && (
-                <div className="flex justify-center mt-4 w-full">
-                    <Button
-                        onClick={toggleExpanded}
-                        variant={"secondary"}
-                        className="flex items-center"
-                    >
-                        <span>{isExpanded ? 'Show Less' : 'Show More'}</span>
-                        {isExpanded ? <ArrowUp className="ml-1 h-4 w-4" /> : <ArrowDown className="h-4 w-4 ml-1" />}
-                    </Button>
-                </div>
+          ))}
+      </div>
+      {list.edges && list.edges.length > quantity && (
+        <div className="flex justify-center mt-4 w-full">
+          <Button
+            onClick={toggleExpanded}
+            variant={"secondary"}
+            className="flex items-center"
+          >
+            <span>{isExpanded ? "Show Less" : "Show More"}</span>
+            {isExpanded ? (
+              <ArrowUp className="ml-1 h-4 w-4" />
+            ) : (
+              <ArrowDown className="h-4 w-4 ml-1" />
             )}
-        </>
-    )
+          </Button>
+        </div>
+      )}
+    </>
+  );
 }

--- a/app/anime/[id]/components/staff-list.tsx
+++ b/app/anime/[id]/components/staff-list.tsx
@@ -6,72 +6,82 @@ import { Button } from "@/components/ui/button";
 
 import { StaffFragment } from "@/graphql/types";
 
-import { ArrowDown, ArrowUp } from 'lucide-react';
+import { ArrowDown, ArrowUp } from "lucide-react";
 import CustomImage from "@/components/ui/custom-image";
 
 interface StaffListProps {
-    quantity?: number;
-    list: StaffFragment[];
+  quantity?: number;
+  list: StaffFragment[];
 }
 
 export function StaffList({ list, quantity }: StaffListProps) {
+  quantity = quantity || list?.length || 5;
 
-    quantity = quantity || list?.length || 5;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const displayedList = isExpanded ? list : list.slice(0, quantity);
 
-    const [isExpanded, setIsExpanded] = useState(false);
-    const displayedList = isExpanded ? list : list.slice(0, quantity);
+  const toggleExpanded = () => {
+    setIsExpanded(!isExpanded);
+  };
 
-    const toggleExpanded = () => {
-        setIsExpanded(!isExpanded);
-    };
+  return (
+    <>
+      <div className="mt-4 flex flex-wrap gap-4 select-none relative">
+        {list && list.length > quantity && !isExpanded && (
+          <div className="absolute inset-0 bottom-0 bg-gradient-to-t from-background via-transparent to-transparent pointer-events-none z-[81]"></div>
+        )}
+        {displayedList &&
+          displayedList.map((character, index) => (
+            <div
+              key={index}
+              className="relative overflow-hidden cursor-pointer group"
+            >
+              <CustomImage
+                index={index}
+                src={character?.node?.image?.large || "/default.png"}
+                alt={character?.node?.name?.userPreferred || "No Title"}
+                width={640}
+                height={600}
+                className="w-full h-full rounded-lg transition-pacity object-cover opacity-80 group-hover:opacity-100"
+              />
 
-    return (
-        <>
-            <div className="mt-4 grid grid-cols-2 md:grid-cols-2 lg:grid-cols-5 gap-4 select-none relative">
-                {list && list.length > quantity && !isExpanded && (
-                    <div className="absolute inset-0 bottom-0 bg-gradient-to-t from-background via-transparent to-transparent pointer-events-none z-[81]"></div>
-                )}
-                {displayedList && displayedList.map((character, index) => (<div
-                    key={index}
-                    className="relative overflow-hidden cursor-pointer group"
-                >
-                    <CustomImage
-
-                        index={index}
-                        src={character?.node?.image?.large || "/default.png"}
-                        alt={character?.node?.name?.userPreferred || "No Title"}
-                        width={640}
-                        height={600}
-                        className="w-full h-full rounded-lg transition-pacity object-cover opacity-80 group-hover:opacity-100"
-                    />
-
-                    <div className="absolute bottom-0 w-full p-4 z-50 font-aeonik">
-                        <h2 className="font-medium text-md lg:w-[80%] leading-5 text-primary/80">
-                            {(character?.node?.name?.userPreferred || "No Title").length > 40
-                                ? (character?.node?.name?.userPreferred || "No Title").slice(0, 37) + "..."
-                                : character?.node?.name?.userPreferred || "No Title"}
-                        </h2>
-                        <p className="text-[12px] mt-1 text-primary/70">
-                            {character?.role ? character?.role.charAt(0) + character?.role.slice(1).toLowerCase() : "Unknown"}
-                        </p>
-                    </div>
-                    {/* Render the anime gradient overlay */}
-                    <div className="absolute inset-0 bg-gradient-to-t from-10% from-black via-[transparent] to-transparent opacity-70 rounded-lg pointer-events-none"></div>
-                </div>
-                ))}
+              <div className="absolute bottom-0 w-full p-4 z-50 font-aeonik">
+                <h2 className="font-medium text-md lg:w-[80%] leading-5 text-primary/80">
+                  {(character?.node?.name?.userPreferred || "No Title").length >
+                  40
+                    ? (
+                        character?.node?.name?.userPreferred || "No Title"
+                      ).slice(0, 37) + "..."
+                    : character?.node?.name?.userPreferred || "No Title"}
+                </h2>
+                <p className="text-[12px] mt-1 text-primary/70">
+                  {character?.role
+                    ? character?.role.charAt(0) +
+                      character?.role.slice(1).toLowerCase()
+                    : "Unknown"}
+                </p>
+              </div>
+              {/* Render the anime gradient overlay */}
+              <div className="absolute inset-0 bg-gradient-to-t from-10% from-black via-[transparent] to-transparent opacity-70 rounded-lg pointer-events-none"></div>
             </div>
-            {list && list.length > quantity && (
-                <div className="flex justify-center mt-4 w-full">
-                    <Button
-                        onClick={toggleExpanded}
-                        variant={"secondary"}
-                        className="flex items-center"
-                    >
-                        <span>{isExpanded ? 'Show Less' : 'Show More'}</span>
-                        {isExpanded ? <ArrowUp className="ml-1 h-4 w-4" /> : <ArrowDown className="h-4 w-4 ml-1" />}
-                    </Button>
-                </div>
+          ))}
+      </div>
+      {list && list.length > quantity && (
+        <div className="flex justify-center mt-4 w-full">
+          <Button
+            onClick={toggleExpanded}
+            variant={"secondary"}
+            className="flex items-center"
+          >
+            <span>{isExpanded ? "Show Less" : "Show More"}</span>
+            {isExpanded ? (
+              <ArrowUp className="ml-1 h-4 w-4" />
+            ) : (
+              <ArrowDown className="h-4 w-4 ml-1" />
             )}
-        </>
-    )
+          </Button>
+        </div>
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
Before:
On smaller screen sizes, there is only 2 columns for Characters Lists and Staff Lists

<img width="803" alt="image" src="https://github.com/user-attachments/assets/db504fff-e893-45f3-881b-a1dbf7ca4c1e">

It is difficult to predict screen sizes, so I suggest that we have it be flex instead. Here are different screen sizes and how they appear using the flex alternative.

1. 
<img width="905" alt="image" src="https://github.com/user-attachments/assets/4a07662d-f165-411a-b102-bd32e84e159b">

2. 
<img width="714" alt="image" src="https://github.com/user-attachments/assets/66ebc7ec-d58f-4474-8243-395664d60181">

3.
<img width="1549" alt="image" src="https://github.com/user-attachments/assets/5ff2605e-02a4-4a60-bcc6-987b39c1aefc">
