### PR TITLE
Removing extra fragment to resolve child comonent keys missing error in AnimeInformation component

### DIFF
--- a/app/anime/[id]/components/information.tsx
+++ b/app/anime/[id]/components/information.tsx
@@ -169,16 +169,14 @@ export function AnimeInformation({
                         <p className="text-sm font-medium text-muted-foreground mt-2">
                             <span className="text-primary font-semibold">Genres:</span>{" "}
                             {data?.Media?.genres?.map((name, index) => (
-                                <>
-                                    <Link
-                                        href={`/search?genre=${name?.toLowerCase()}`}
-                                        key={index}
-                                        className="hover:text-primary cursor-pointer select-none"
-                                    >
-                                        {name}
-                                        {index < (data?.Media?.genres?.length || 0) - 1 && ", "}
-                                    </Link>
-                                </>
+                                <Link
+                                    href={`/search?genre=${name?.toLowerCase()}`}
+                                    key={index}
+                                    className="hover:text-primary cursor-pointer select-none"
+                                >
+                                    {name}
+                                    {index < (data?.Media?.genres?.length || 0) - 1 && ", "}
+                                </Link>
                             ))}
                         </p>
                         <p className="text-sm font-medium text-muted-foreground mt-2">


### PR DESCRIPTION
I saw this error in the dev tools and found that there was an extra fragment wrapping the Link, so I removed it.

![image](https://github.com/user-attachments/assets/8570e26f-3369-4760-bffd-d7b65c2d8e2f)
